### PR TITLE
Implement DropdownListMenu on PinnedMenu icons

### DIFF
--- a/src/sidemenu/PinnedMenu.tsx
+++ b/src/sidemenu/PinnedMenu.tsx
@@ -2,6 +2,7 @@ import CircleButton, {
   CircleButtonProps,
   SelectLightPosition,
 } from "../buttons/CircleButton";
+import DropdownListMenu, { DropdownProps, DropdownStyle } from "../common/DropdownListMenu";
 import Icon, { IconProps } from "../common/Icon";
 
 import ActionLink from "../buttons/ActionLink";
@@ -17,6 +18,8 @@ interface PinnedMenuItemProps {
   item: BoardType | CircleButtonProps;
   current: boolean;
   loading?: false;
+  menuOptions?: DropdownProps["options"];
+  label?: string;
 }
 
 interface LoadingPinnedMenuItemProps {
@@ -27,7 +30,7 @@ interface LoadingPinnedMenuItemProps {
 const PinnedMenuItem: React.FC<
   PinnedMenuItemProps | LoadingPinnedMenuItemProps
 > = (props) => {
-  const { item, current } = props as PinnedMenuItemProps;
+  const { item, current, menuOptions, label } = props as PinnedMenuItemProps;
   const { loading, loadingAccentColor } = props as LoadingPinnedMenuItemProps;
 
   return (
@@ -45,14 +48,39 @@ const PinnedMenuItem: React.FC<
         <ActionLink link={item.link}>
           <BoardIcon {...item} current={current} large />
         </ActionLink>
+      ) : !!menuOptions?.length? (
+        <div className="dropdown-wrapper">
+          <DropdownListMenu
+          options={menuOptions}
+          style={DropdownStyle.DARK}
+          label={label}
+          >
+            <CircleButton
+              {...item}
+              withDropdown={!!menuOptions?.length}
+            />
+          </DropdownListMenu> 
+        </div>
       ) : (
-        <CircleButton
+        <div className="button-wrapper">
+          <CircleButton
           {...item}
+          withDropdown={!!menuOptions?.length}
           selected={current}
           selectLightPosition={SelectLightPosition.LEFT}
-        />
+          />
+        </div>
       )}
       <style jsx>{`
+        .button-wrapper {
+          width: 100%;
+        }
+        .dropdown-wrapper {
+          display: flex;
+          width: 100%;
+          align-items: center; 
+          justify-content: center; 
+        }
         .pinned-item {
           margin-top: 15px;
           padding: 0 7px;
@@ -63,6 +91,8 @@ const PinnedMenuItem: React.FC<
           margin-top: 8px;
           padding: 0;
           width: 100%;
+          display: flex;
+          align-items: center;
         }
         .pinned-item:first-child {
           margin-top: 10px;
@@ -79,8 +109,7 @@ const Section: React.FC<PinnedMenuSectionProps> = (props) => {
   const { icon } = props as BasePinnedSectionProps;
   const {
     items,
-    currentItemId: currentItemSlug,
-  } = props as WithPinnedSectionProps;
+    currentItemId: currentItemSlug  } = props as WithPinnedSectionProps;
   const {
     loading,
     loadingAccentColor,
@@ -105,6 +134,8 @@ const Section: React.FC<PinnedMenuSectionProps> = (props) => {
           <PinnedMenuItem
             key={index}
             item={item}
+            label={"slug" in item ? item.slug : item.id}
+            menuOptions={"menuOptions" in item ? item.menuOptions : []}
             current={currentItemSlug == ("slug" in item ? item.slug : item.id)}
           />
         ))}
@@ -193,7 +224,9 @@ export interface BasePinnedSectionProps {
   icon: IconProps["icon"];
 }
 export interface WithPinnedSectionProps {
-  items: (BoardType | (CircleButtonProps & { id: string }))[];
+  items: (BoardType | (CircleButtonProps & { 
+    id: string, 
+    menuOptions?: DropdownProps["options"] }))[];
   currentItemId?: string | null;
   loading?: false;
 }

--- a/stories/20-SideMenu/01-PinnedMenu.stories.tsx
+++ b/stories/20-SideMenu/01-PinnedMenu.stories.tsx
@@ -1,8 +1,6 @@
-import React from "react";
 import PinnedMenu, {
   PinnedMenuSectionProps,
 } from "../../src/sidemenu/PinnedMenu";
-
 import {
   faHeart,
   faInbox,
@@ -12,18 +10,17 @@ import {
   faUpload,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { action } from "@storybook/addon-actions";
-
-import goreBackground from "../images/gore.png";
-
-import mamoru from "../images/mamoru.png";
-import anime from "../images/anime.png";
-import crack from "../images/crack.png";
-import oncelerBoard from "../images/onceler-board.png";
-import meta from "../images/meta.png";
-import book from "../images/book.png";
-import kinkmeme from "../images/kink-meme.png";
+import React from "react";
 import { Story } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import anime from "../images/anime.png";
+import book from "../images/book.png";
+import crack from "../images/crack.png";
+import goreBackground from "../images/gore.png";
+import kinkmeme from "../images/kink-meme.png";
+import mamoru from "../images/mamoru.png";
+import meta from "../images/meta.png";
+import oncelerBoard from "../images/onceler-board.png";
 
 const PINNED_BOARDS = [
   {
@@ -160,7 +157,21 @@ Icons.args = {
       accentColor: "red",
       withNotification: true,
     },
-    { id: "image", icon: mamoru, accentColor: "red", withDropdown: true },
+    { 
+      id: "user options", 
+      icon: mamoru, 
+      accentColor: "red", 
+      menuOptions : [
+        {
+          name: "Option 1",
+          link: { href: "#opt1", onClick: action("#opt1") },
+        },
+        {
+          name: "Option 2",
+          link: { href: "#opt2", onClick: action("#opt2") },
+        }
+      ],
+    },
     {
       id: "heart",
       icon: faHeart,
@@ -180,7 +191,19 @@ Mixed.args = {
       accentColor: "red",
     },
     PINNED_BOARDS[0],
-    { id: "image", icon: mamoru, accentColor: "red", withDropdown: true },
+    { id: "user options", 
+    icon: mamoru, 
+    accentColor: "red", 
+    menuOptions : [
+      {
+        name: "Option 1",
+        link: { href: "#opt1", onClick: action("#opt1") },
+      },
+      {
+        name: "Option 2",
+        link: { href: "#opt2", onClick: action("#opt2") },
+      }
+    ], },
     PINNED_BOARDS[2],
     { id: "heart", icon: faHeart, accentColor: "red" },
   ],


### PR DESCRIPTION
I feel like there should have been a way to not have to pass the `menuOptions` separately to `PinnedMenuItem` since you're already passing the `item`, but I couldn't make it work to be able to access `item.menuOptions` even when I tried making the `item` type declaration for `PinnedMenuItemProps` the same as worked for `WithPinnedSectionProps`, so :/